### PR TITLE
Release 1.5.001 YAML updates

### DIFF
--- a/deployment/coe-es-mongodb.yaml
+++ b/deployment/coe-es-mongodb.yaml
@@ -5,6 +5,10 @@ metadata:
 data:
   lstreamd_default.conf: |
     {
+        "transRateLimitEnabled": "no",
+        "transRateLimit": "100",
+        "transQueueLimit": "1024",
+        "transRateLimitWindow": "5",
         "Endpoints": {
             "ES": {
                 "ServerUrl": "elasticsearch.default.svc.cluster.local:9200",
@@ -53,7 +57,7 @@ spec:
     spec:
       containers:
         - name: coe-es
-          image: "quay.io/citrix/citrix-observability-exporter:1.4.001"
+          image: "quay.io/citrix/citrix-observability-exporter:1.5.001"
           imagePullPolicy: Always
           ports:
             - containerPort: 5557

--- a/deployment/coe-es-prometheus.yaml
+++ b/deployment/coe-es-prometheus.yaml
@@ -5,6 +5,10 @@ metadata:
 data:
   lstreamd_default.conf: |
     {
+        "transRateLimitEnabled": "no",
+        "transRateLimit": "100",
+        "transQueueLimit": "1024",
+        "transRateLimitWindow": "5",
         "Endpoints": {
             "ES": {
                 "ServerUrl": "elasticsearch.default.svc.cluster.local:9200",
@@ -56,7 +60,7 @@ spec:
     spec:
       containers:
         - name: coe-es
-          image: "quay.io/citrix/citrix-observability-exporter:1.4.001"
+          image: "quay.io/citrix/citrix-observability-exporter:1.5.001"
           imagePullPolicy: Always
           securityContext:
             privileged: true

--- a/deployment/coe-es.yaml
+++ b/deployment/coe-es.yaml
@@ -5,6 +5,10 @@ metadata:
 data:
   lstreamd_default.conf: |
     {
+        "transRateLimitEnabled": "no",
+        "transRateLimit": "100",
+        "transQueueLimit": "1024",
+        "transRateLimitWindow": "5",
         "Endpoints": {
             "ES": {
                 "ServerUrl": "elasticsearch.default.svc.cluster.local:9200",
@@ -53,7 +57,7 @@ spec:
     spec:
       containers:
         - name: coe-es
-          image: "quay.io/citrix/citrix-observability-exporter:1.4.001"
+          image: "quay.io/citrix/citrix-observability-exporter:1.5.001"
           imagePullPolicy: Always
           ports:
             - containerPort: 5557

--- a/deployment/coe-kafka.yaml
+++ b/deployment/coe-kafka.yaml
@@ -63,7 +63,7 @@ spec:
             - "kafka-node3"
       containers:
         - name: coe-kafka
-          image: "quay.io/citrix/citrix-observability-exporter:1.4.001"
+          image: "quay.io/citrix/citrix-observability-exporter:1.5.001"
           imagePullPolicy: Always
           ports:
             - containerPort: 5557

--- a/deployment/coe-prometheus.yaml
+++ b/deployment/coe-prometheus.yaml
@@ -32,7 +32,7 @@ spec:
     spec:
       containers:
         - name: coe-prometheus
-          image: "quay.io/citrix/citrix-observability-exporter:1.4.001"
+          image: "quay.io/citrix/citrix-observability-exporter:1.5.001"
           imagePullPolicy: Always
           securityContext:
             privileged: true

--- a/deployment/coe-splunk.yaml
+++ b/deployment/coe-splunk.yaml
@@ -4,37 +4,41 @@ metadata:
   name: coe-config-splunk
 data:
   lstreamd_default.conf: |
-  {
-    "Endpoints": {
-      "SPLUNK": {
-        "ServerUrl": "",
-        "AuthToken": "",
-        "Index": "",
-        "RecordType": {
-          "HTTP": "all",
-          "TCP": "all",
-          "SWG": "all",
-          "VPN": "all",
-          "NGS": "all",
-          "ICA": "all",
-          "APPFW": "none",
-          "BOT": "all",
-          "VIDEOOPT": "none",
-          "BURST_CQA": "none",
-          "SLA": "none",
-          "MONGO": "none"
-        },
-        "TimeSeries": {
-          "EVENTS": "no",
-          "AUDITLOGS": "no"
-        },
-        "ProcessAlways": "no",
-        "ProcessYieldTimeOut": "500",
-        "MaxConnections": "512",
-        "JsonFileDump": "no"           
+    {
+      "transRateLimitEnabled": "no",
+      "transRateLimit": "100",
+      "transQueueLimit": "1024",
+      "transRateLimitWindow": "5",
+      "Endpoints": {
+        "SPLUNK": {
+          "ServerUrl": "",
+          "AuthToken": "",
+          "Index": "",
+          "RecordType": {
+            "HTTP": "all",
+            "TCP": "all",
+            "SWG": "all",
+            "VPN": "all",
+            "NGS": "all",
+            "ICA": "all",
+            "APPFW": "none",
+            "BOT": "all",
+            "VIDEOOPT": "none",
+            "BURST_CQA": "none",
+            "SLA": "none",
+            "MONGO": "none"
+          },
+          "TimeSeries": {
+            "EVENTS": "no",
+            "AUDITLOGS": "no"
+          },
+          "ProcessAlways": "no",
+          "ProcessYieldTimeOut": "500",
+          "MaxConnections": "512",
+          "JsonFileDump": "no"           
+        }
       }
     }
-  }
 ---
 
 apiVersion: apps/v1
@@ -59,7 +63,7 @@ spec:
     spec:
       containers:
         - name: coe-splunk
-          image: "quay.io/citrix/citrix-observability-exporter:1.4.001"
+          image: "quay.io/citrix/citrix-observability-exporter:1.5.001"
           imagePullPolicy: Always
           ports:
             - containerPort: 5557

--- a/deployment/coe-zipkin.yaml
+++ b/deployment/coe-zipkin.yaml
@@ -5,6 +5,10 @@ metadata:
 data:
   lstreamd_default.conf: |
     {
+        "transRateLimitEnabled": "no",
+        "transRateLimit": "100",
+        "transQueueLimit": "1024",
+        "transRateLimitWindow": "5",
         "Endpoints": {
           "ZIPKIN": {
             "ServerUrl": "zipkin.default.svc.cluster.local:9411/api/v1/spans",
@@ -42,7 +46,7 @@ spec:
     spec:
       containers:
         - name: coe-zipkin
-          image: "quay.io/citrix/citrix-observability-exporter:1.4.001"
+          image: "quay.io/citrix/citrix-observability-exporter:1.5.001"
           imagePullPolicy: Always
           securityContext:
             privileged: true

--- a/examples/elasticsearch/coe-es-mongodb.yaml
+++ b/examples/elasticsearch/coe-es-mongodb.yaml
@@ -5,6 +5,10 @@ metadata:
 data:
   lstreamd_default.conf: |
     {
+        "transRateLimitEnabled": "no",
+        "transRateLimit": "100",
+        "transQueueLimit": "1024",
+        "transRateLimitWindow": "5",
         "Endpoints": {
             "ES": {
                 "ServerUrl": "elasticsearch.default.svc.cluster.local:9200",
@@ -53,7 +57,7 @@ spec:
     spec:
       containers:
         - name: coe-es
-          image: "quay.io/citrix/citrix-observability-exporter:1.4.001"
+          image: "quay.io/citrix/citrix-observability-exporter:1.5.001"
           imagePullPolicy: Always
           ports:
             - containerPort: 5557

--- a/examples/elasticsearch/coe-es-prometheus.yaml
+++ b/examples/elasticsearch/coe-es-prometheus.yaml
@@ -5,6 +5,10 @@ metadata:
 data:
   lstreamd_default.conf: |
     {
+        "transRateLimitEnabled": "no",
+        "transRateLimit": "100",
+        "transQueueLimit": "1024",
+        "transRateLimitWindow": "5",
         "Endpoints": {
             "ES": {
                 "ServerUrl": "elasticsearch.default.svc.cluster.local:9200",
@@ -56,7 +60,7 @@ spec:
     spec:
       containers:
         - name: coe-es
-          image: "quay.io/citrix/citrix-observability-exporter:1.4.001"
+          image: "quay.io/citrix/citrix-observability-exporter:1.5.001"
           imagePullPolicy: Always
           securityContext:
             privileged: true

--- a/examples/elasticsearch/coe-es.yaml
+++ b/examples/elasticsearch/coe-es.yaml
@@ -5,6 +5,10 @@ metadata:
 data:
   lstreamd_default.conf: |
     {
+        "transRateLimitEnabled": "no",
+        "transRateLimit": "100",
+        "transQueueLimit": "1024",
+        "transRateLimitWindow": "5",
         "Endpoints": {
             "ES": {
                 "ServerUrl": "elasticsearch.default.svc.cluster.local:9200",
@@ -53,7 +57,7 @@ spec:
     spec:
       containers:
         - name: coe-es
-          image: "quay.io/citrix/citrix-observability-exporter:1.4.001"
+          image: "quay.io/citrix/citrix-observability-exporter:1.5.001"
           imagePullPolicy: Always
           ports:
             - containerPort: 5557

--- a/examples/kafka/coe-kafka.yaml
+++ b/examples/kafka/coe-kafka.yaml
@@ -63,7 +63,7 @@ spec:
             - "kafka-node3"
       containers:
         - name: coe-kafka
-          image: "quay.io/citrix/citrix-observability-exporter:1.4.001"
+          image: "quay.io/citrix/citrix-observability-exporter:1.5.001"
           imagePullPolicy: Always
           ports:
             - containerPort: 5557

--- a/examples/prometheus/coe-prometheus.yaml
+++ b/examples/prometheus/coe-prometheus.yaml
@@ -32,7 +32,7 @@ spec:
     spec:
       containers:
         - name: coe-prometheus
-          image: "quay.io/citrix/citrix-observability-exporter:1.4.001"
+          image: "quay.io/citrix/citrix-observability-exporter:1.5.001"
           imagePullPolicy: Always
           securityContext:
             privileged: true

--- a/examples/splunk/coe-splunk.yaml
+++ b/examples/splunk/coe-splunk.yaml
@@ -4,37 +4,41 @@ metadata:
   name: coe-config-splunk
 data:
   lstreamd_default.conf: |
-  {
-    "Endpoints": {
-      "SPLUNK": {
-        "ServerUrl": "",
-        "AuthToken": "",
-        "Index": "",
-        "RecordType": {
-          "HTTP": "all",
-          "TCP": "all",
-          "SWG": "all",
-          "VPN": "all",
-          "NGS": "all",
-          "ICA": "all",
-          "APPFW": "none",
-          "BOT": "all",
-          "VIDEOOPT": "none",
-          "BURST_CQA": "none",
-          "SLA": "none",
-          "MONGO": "none"
-        },
-        "TimeSeries": {
-          "EVENTS": "no",
-          "AUDITLOGS": "no"
-        },
-        "ProcessAlways": "no",
-        "ProcessYieldTimeOut": "500",
-        "MaxConnections": "512",
-        "JsonFileDump": "no"           
+    {
+      "transRateLimitEnabled": "no",
+      "transRateLimit": "100",
+      "transQueueLimit": "1024",
+      "transRateLimitWindow": "5",
+      "Endpoints": {
+        "SPLUNK": {
+          "ServerUrl": "",
+          "AuthToken": "",
+          "Index": "",
+          "RecordType": {
+            "HTTP": "all",
+            "TCP": "all",
+            "SWG": "all",
+            "VPN": "all",
+            "NGS": "all",
+            "ICA": "all",
+            "APPFW": "none",
+            "BOT": "all",
+            "VIDEOOPT": "none",
+            "BURST_CQA": "none",
+            "SLA": "none",
+            "MONGO": "none"
+          },
+          "TimeSeries": {
+            "EVENTS": "no",
+            "AUDITLOGS": "no"
+          },
+          "ProcessAlways": "no",
+          "ProcessYieldTimeOut": "500",
+          "MaxConnections": "512",
+          "JsonFileDump": "no"           
+        }
       }
     }
-  }
 ---
 
 apiVersion: apps/v1
@@ -59,7 +63,7 @@ spec:
     spec:
       containers:
         - name: coe-splunk
-          image: "quay.io/citrix/citrix-observability-exporter:1.4.001"
+          image: "quay.io/citrix/citrix-observability-exporter:1.5.001"
           imagePullPolicy: Always
           ports:
             - containerPort: 5557

--- a/examples/tracing/coe-zipkin.yaml
+++ b/examples/tracing/coe-zipkin.yaml
@@ -5,6 +5,10 @@ metadata:
 data:
   lstreamd_default.conf: |
     {
+        "transRateLimitEnabled": "no",
+        "transRateLimit": "100",
+        "transQueueLimit": "1024",
+        "transRateLimitWindow": "5",
         "Endpoints": {
           "ZIPKIN": {
             "ServerUrl": "zipkin.default.svc.cluster.local:9411/api/v1/spans",
@@ -42,7 +46,7 @@ spec:
     spec:
       containers:
         - name: coe-zipkin
-          image: "quay.io/citrix/citrix-observability-exporter:1.4.001"
+          image: "quay.io/citrix/citrix-observability-exporter:1.5.001"
           imagePullPolicy: Always
           securityContext:
             privileged: true


### PR DESCRIPTION
Release 1.5.001 adds RL support for JSON Based Endpoints- Splunk, ElasticSearch and Zipkin, and allows COE to run as a non-root user (uname=coe_guest, uid=1000, gid=1000).

While the latter didn't require configuration changes, the former required changes in lstreamd.conf

This PR address two things:
 (1) Bumping up the version of COE in YAMLs- The MD files remain unaltered.
 (2) Changes in lstreamd.conf to support RL- By default RL is disabled ( transRateLimitEnabled: "no"). To enable RL, set transRateLimitEnabled: "yes".