### PR TITLE
COE Release 1.6.001

### DIFF
--- a/coe-on-standalone-linux.md
+++ b/coe-on-standalone-linux.md
@@ -25,7 +25,7 @@ Perform the following steps to deploy Citrix ADC Observability Exporter on a sta
             privileged: true
             volumes:
               - ./lstreamd_default.conf:/var/logproxy/lstreamd/conf/lstreamd_default.conf:rw
-              - ./var/crash/:/var/crash/:rw
+              - ./cores:/var/crash/:rw
       ```
 
     **Note:** Currently the image tag `quay.io/citrix/citrix-observability-exporter:latest` corresponds to Citrix ADC Observability Exporter version 1.2.001 and not 1.4.001.

--- a/coe-on-standalone-linux.md
+++ b/coe-on-standalone-linux.md
@@ -25,7 +25,7 @@ Perform the following steps to deploy Citrix ADC Observability Exporter on a sta
             privileged: true
             volumes:
               - ./lstreamd_default.conf:/var/logproxy/lstreamd/conf/lstreamd_default.conf:rw
-              - ./cores/:/cores/:rw
+              - ./var/crash/:/var/crash/:rw
       ```
 
     **Note:** Currently the image tag `quay.io/citrix/citrix-observability-exporter:latest` corresponds to Citrix ADC Observability Exporter version 1.2.001 and not 1.4.001.

--- a/deployment/coe-es-mongodb.yaml
+++ b/deployment/coe-es-mongodb.yaml
@@ -57,7 +57,7 @@ spec:
     spec:
       containers:
         - name: coe-es
-          image: "quay.io/citrix/citrix-observability-exporter:1.5.001"
+          image: "quay.io/citrix/citrix-observability-exporter:1.6.001"
           imagePullPolicy: Always
           ports:
             - containerPort: 5557
@@ -67,7 +67,7 @@ spec:
               mountPath: /var/logproxy/lstreamd/conf/lstreamd_default.conf
               subPath: lstreamd_default.conf
             - name: core-data
-              mountPath: /cores/
+              mountPath: /var/crash/
       volumes:
         - name: lstreamd-config-es
           configMap:

--- a/deployment/coe-es-prometheus.yaml
+++ b/deployment/coe-es-prometheus.yaml
@@ -60,7 +60,7 @@ spec:
     spec:
       containers:
         - name: coe-es
-          image: "quay.io/citrix/citrix-observability-exporter:1.5.001"
+          image: "quay.io/citrix/citrix-observability-exporter:1.6.001"
           imagePullPolicy: Always
           securityContext:
             privileged: true
@@ -74,7 +74,7 @@ spec:
               mountPath: /var/logproxy/lstreamd/conf/lstreamd_default.conf
               subPath: lstreamd_default.conf
             - name: core-data
-              mountPath: /cores/
+              mountPath: /var/crash/
       volumes:
         - name: lstreamd-config-es
           configMap:

--- a/deployment/coe-es.yaml
+++ b/deployment/coe-es.yaml
@@ -57,7 +57,7 @@ spec:
     spec:
       containers:
         - name: coe-es
-          image: "quay.io/citrix/citrix-observability-exporter:1.5.001"
+          image: "quay.io/citrix/citrix-observability-exporter:1.6.001"
           imagePullPolicy: Always
           ports:
             - containerPort: 5557
@@ -67,7 +67,7 @@ spec:
               mountPath: /var/logproxy/lstreamd/conf/lstreamd_default.conf
               subPath: lstreamd_default.conf
             - name: core-data
-              mountPath: /cores/
+              mountPath: /var/crash/
       volumes:
         - name: lstreamd-config-es
           configMap:

--- a/deployment/coe-kafka.yaml
+++ b/deployment/coe-kafka.yaml
@@ -9,6 +9,7 @@ data:
           "KAFKA": {
             "ServerUrl": "X.X.X.X:9092",
             "KafkaTopic": "HTTP",
+            "DataFormat": "AVRO",
             "RecordType": {
                 "HTTP": "all",
                 "TCP": "all",
@@ -63,7 +64,7 @@ spec:
             - "kafka-node3"
       containers:
         - name: coe-kafka
-          image: "quay.io/citrix/citrix-observability-exporter:1.5.001"
+          image: "quay.io/citrix/citrix-observability-exporter:1.6.001"
           imagePullPolicy: Always
           ports:
             - containerPort: 5557
@@ -73,7 +74,7 @@ spec:
               mountPath: /var/logproxy/lstreamd/conf/lstreamd_default.conf
               subPath: lstreamd_default.conf
             - name: core-data
-              mountPath: /cores/
+              mountPath: /var/crash/
       volumes:
         - name: lstreamd-config-kafka
           configMap:

--- a/deployment/coe-prometheus.yaml
+++ b/deployment/coe-prometheus.yaml
@@ -32,7 +32,7 @@ spec:
     spec:
       containers:
         - name: coe-prometheus
-          image: "quay.io/citrix/citrix-observability-exporter:1.5.001"
+          image: "quay.io/citrix/citrix-observability-exporter:1.6.001"
           imagePullPolicy: Always
           securityContext:
             privileged: true
@@ -44,7 +44,7 @@ spec:
               mountPath: /var/logproxy/lstreamd/conf/lstreamd_default.conf
               subPath: lstreamd_default.conf
             - name: core-data
-              mountPath: /cores/
+              mountPath: /var/crash/
       volumes:
         - name: lstreamd-config-prometheus
           configMap:

--- a/deployment/coe-splunk.yaml
+++ b/deployment/coe-splunk.yaml
@@ -63,7 +63,7 @@ spec:
     spec:
       containers:
         - name: coe-splunk
-          image: "quay.io/citrix/citrix-observability-exporter:1.5.001"
+          image: "quay.io/citrix/citrix-observability-exporter:1.6.001"
           imagePullPolicy: Always
           ports:
             - containerPort: 5557
@@ -75,7 +75,7 @@ spec:
               mountPath: /var/logproxy/lstreamd/conf/lstreamd_default.conf
               subPath: lstreamd_default.conf
             - name: core-data
-              mountPath: /cores/
+              mountPath: /var/crash/
       volumes:
         - name: lstreamd-config-splunk
           configMap:

--- a/deployment/coe-zipkin.yaml
+++ b/deployment/coe-zipkin.yaml
@@ -46,7 +46,7 @@ spec:
     spec:
       containers:
         - name: coe-zipkin
-          image: "quay.io/citrix/citrix-observability-exporter:1.5.001"
+          image: "quay.io/citrix/citrix-observability-exporter:1.6.001"
           imagePullPolicy: Always
           securityContext:
             privileged: true
@@ -58,7 +58,7 @@ spec:
               mountPath: /var/logproxy/lstreamd/conf/lstreamd_default.conf
               subPath: lstreamd_default.conf
             - name: core-data
-              mountPath: /cores/
+              mountPath: /var/crash/
       volumes:
         - name: lstreamd-config-zipkin
           configMap:

--- a/docs/coe-troubleshooting.md
+++ b/docs/coe-troubleshooting.md
@@ -41,7 +41,7 @@ This document explains how to troubleshoot issues that you may encounter while u
 
     If Citrix ADC Observability Exporter fails, you can collect logs available at the following location and contact Citrix Support.
 
-        /cores/ (Loation of coredump files, if any.)
+        /var/crash/ (Loation of coredump files, if any.)
         /var/ulflog/ (Location of `libulfd` logs and counter details.)
         /var/log  (Location of console logs, lstreamd logs and so on.)
 

--- a/docs/deploy-coe-with-Kafka.md
+++ b/docs/deploy-coe-with-Kafka.md
@@ -155,7 +155,7 @@ To edit the YAML file for the required changes, perform the following steps:
                   mountPath: /var/logproxy/lstreamd/conf/lstreamd_default.conf
                   subPath: lstreamd_default.conf
                 - name: core-data
-                  mountPath: /cores/
+                  mountPath: /var/crash/
           volumes:
             - name: lstreamd-config-kafka
               configMap:

--- a/docs/deploy-coe-with-es.md
+++ b/docs/deploy-coe-with-es.md
@@ -213,7 +213,7 @@ To verify if Citrix ADC sends application data logs to Citrix ADC Observability 
 
   If Citrix ADC Observability Exporter fails, you can collect logs and files available at the following location and contact Citrix Support.
 
-          /cores/ (Loation of the coredump files, if any.)
+          /var/crash/ (Loation of the coredump files, if any.)
           /var/ulflog/ (Location of the `libulfd` logs and counter details.)
           /var/log  (Location of the console logs, lstreamd logs and so on.)
 

--- a/examples/elasticsearch/coe-es-mongodb.yaml
+++ b/examples/elasticsearch/coe-es-mongodb.yaml
@@ -57,7 +57,7 @@ spec:
     spec:
       containers:
         - name: coe-es
-          image: "quay.io/citrix/citrix-observability-exporter:1.5.001"
+          image: "quay.io/citrix/citrix-observability-exporter:1.6.001"
           imagePullPolicy: Always
           ports:
             - containerPort: 5557

--- a/examples/elasticsearch/coe-es-mongodb.yaml
+++ b/examples/elasticsearch/coe-es-mongodb.yaml
@@ -67,7 +67,7 @@ spec:
               mountPath: /var/logproxy/lstreamd/conf/lstreamd_default.conf
               subPath: lstreamd_default.conf
             - name: core-data
-              mountPath: /cores/
+              mountPath: /var/crash/
       volumes:
         - name: lstreamd-config-es
           configMap:

--- a/examples/elasticsearch/coe-es-prometheus.yaml
+++ b/examples/elasticsearch/coe-es-prometheus.yaml
@@ -60,7 +60,7 @@ spec:
     spec:
       containers:
         - name: coe-es
-          image: "quay.io/citrix/citrix-observability-exporter:1.5.001"
+          image: "quay.io/citrix/citrix-observability-exporter:1.6.001"
           imagePullPolicy: Always
           securityContext:
             privileged: true

--- a/examples/elasticsearch/coe-es-prometheus.yaml
+++ b/examples/elasticsearch/coe-es-prometheus.yaml
@@ -74,7 +74,7 @@ spec:
               mountPath: /var/logproxy/lstreamd/conf/lstreamd_default.conf
               subPath: lstreamd_default.conf
             - name: core-data
-              mountPath: /cores/
+              mountPath: /var/crash/
       volumes:
         - name: lstreamd-config-es
           configMap:

--- a/examples/elasticsearch/coe-es.yaml
+++ b/examples/elasticsearch/coe-es.yaml
@@ -57,7 +57,7 @@ spec:
     spec:
       containers:
         - name: coe-es
-          image: "quay.io/citrix/citrix-observability-exporter:1.5.001"
+          image: "quay.io/citrix/citrix-observability-exporter:1.6.001"
           imagePullPolicy: Always
           ports:
             - containerPort: 5557

--- a/examples/elasticsearch/coe-es.yaml
+++ b/examples/elasticsearch/coe-es.yaml
@@ -67,7 +67,7 @@ spec:
               mountPath: /var/logproxy/lstreamd/conf/lstreamd_default.conf
               subPath: lstreamd_default.conf
             - name: core-data
-              mountPath: /cores/
+              mountPath: /var/crash/
       volumes:
         - name: lstreamd-config-es
           configMap:

--- a/examples/kafka/coe-kafka.yaml
+++ b/examples/kafka/coe-kafka.yaml
@@ -9,6 +9,7 @@ data:
           "KAFKA": {
             "ServerUrl": "X.X.X.X:9092",
             "KafkaTopic": "HTTP",
+            "DataFormat": "AVRO",
             "RecordType": {
                 "HTTP": "all",
                 "TCP": "all",
@@ -63,7 +64,7 @@ spec:
             - "kafka-node3"
       containers:
         - name: coe-kafka
-          image: "quay.io/citrix/citrix-observability-exporter:1.5.001"
+          image: "quay.io/citrix/citrix-observability-exporter:1.6.001"
           imagePullPolicy: Always
           ports:
             - containerPort: 5557

--- a/examples/kafka/coe-kafka.yaml
+++ b/examples/kafka/coe-kafka.yaml
@@ -74,7 +74,7 @@ spec:
               mountPath: /var/logproxy/lstreamd/conf/lstreamd_default.conf
               subPath: lstreamd_default.conf
             - name: core-data
-              mountPath: /cores/
+              mountPath: /var/crash/
       volumes:
         - name: lstreamd-config-kafka
           configMap:

--- a/examples/prometheus/coe-prometheus.yaml
+++ b/examples/prometheus/coe-prometheus.yaml
@@ -32,7 +32,7 @@ spec:
     spec:
       containers:
         - name: coe-prometheus
-          image: "quay.io/citrix/citrix-observability-exporter:1.5.001"
+          image: "quay.io/citrix/citrix-observability-exporter:1.6.001"
           imagePullPolicy: Always
           securityContext:
             privileged: true

--- a/examples/prometheus/coe-prometheus.yaml
+++ b/examples/prometheus/coe-prometheus.yaml
@@ -44,7 +44,7 @@ spec:
               mountPath: /var/logproxy/lstreamd/conf/lstreamd_default.conf
               subPath: lstreamd_default.conf
             - name: core-data
-              mountPath: /cores/
+              mountPath: /var/crash/
       volumes:
         - name: lstreamd-config-prometheus
           configMap:

--- a/examples/splunk/coe-splunk.yaml
+++ b/examples/splunk/coe-splunk.yaml
@@ -63,7 +63,7 @@ spec:
     spec:
       containers:
         - name: coe-splunk
-          image: "quay.io/citrix/citrix-observability-exporter:1.5.001"
+          image: "quay.io/citrix/citrix-observability-exporter:1.6.001"
           imagePullPolicy: Always
           ports:
             - containerPort: 5557

--- a/examples/tracing/coe-zipkin.yaml
+++ b/examples/tracing/coe-zipkin.yaml
@@ -58,7 +58,7 @@ spec:
               mountPath: /var/logproxy/lstreamd/conf/lstreamd_default.conf
               subPath: lstreamd_default.conf
             - name: core-data
-              mountPath: /cores/
+              mountPath: /var/crash/
       volumes:
         - name: lstreamd-config-zipkin
           configMap:

--- a/examples/tracing/coe-zipkin.yaml
+++ b/examples/tracing/coe-zipkin.yaml
@@ -46,7 +46,7 @@ spec:
     spec:
       containers:
         - name: coe-zipkin
-          image: "quay.io/citrix/citrix-observability-exporter:1.5.001"
+          image: "quay.io/citrix/citrix-observability-exporter:1.6.001"
           imagePullPolicy: Always
           securityContext:
             privileged: true


### PR DESCRIPTION
COE Release 1.6.001
=================
1. JSON Transaction export to Kafka from COE [new feature]
2. nobody/nogroup low priv user/group for OpenShift and Kubernetes [enhancement]
3. Fix COE not logging HTTP response status code [bug fix]
4. Fix corrupted JSON fields like srcMetadataJSON, srcLabelsJSON, dstMetadataJSON, dstLabelsJSON [bug fix]
5. /var/crash is the default core pattern on linux -- changed the /cores folder for that.